### PR TITLE
support loading and saving models

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,25 @@ Ave Test loss: 0.025
 ```
 ![Comparison](https://github.com/guanyilun/galilei/raw/master/data/demo.png)
 
+You can also easily save your trained model with the `save` option
+```python
+@emulate(samples={
+    'a': np.random.rand(100),
+    'b': np.random.rand(100)
+}, backend='sklearn', save="test.pkl")
+def test(a=1, b=1):
+    x = np.linspace(0, 10, 100)
+    return np.sin(a*x) + np.sin(b*x)
+```
+and when you use it in production, simply load a pretrained model with
+```python
+@emulate(backend='sklearn', load="test.pkl")
+def test(a=1, b=1):
+    x = np.linspace(0, 10, 100)
+    return np.sin(a*x) + np.sin(b*x)
+```
+and your function will be replaced with a fast emulated version.
+
 For more detailed usage examples, see this notebook:
 <a href="https://colab.research.google.com/drive/1_pvuAIqLUz4gV1vxytueb7AMR6Jmx-8n?usp=sharing">
 <img src="https://user-content.gitlab-static.net/dfbb2c197c959c47da3e225b71504edb540e21d6/68747470733a2f2f636f6c61622e72657365617263682e676f6f676c652e636f6d2f6173736574732f636f6c61622d62616467652e737667" alt="open in colab">

--- a/galilei/emulator.py
+++ b/galilei/emulator.py
@@ -26,16 +26,16 @@ class Net(nn.Module):
             List of hidden layer sizes
         """
         super(Net, self).__init__()
-        self.layer0 = nn.Linear(idim, hidden[0])
+        self.layers = nn.ModuleList()
+        self.layers.append(nn.Linear(idim, hidden[0]))
         for i in range(1, len(hidden)):
-            self.add_module("layer" + str(i), nn.Linear(hidden[i - 1], hidden[i - 1]))
-        self.add_module("layer" + str(len(hidden)), nn.Linear(hidden[-1], odim))
+            self.layers.append(nn.Linear(hidden[i - 1], hidden[i]))
+        self.layers.append(nn.Linear(hidden[-1], odim))
 
     def forward(self, out):
-        for i in range(len(self._modules) - 1):
-            out = self._modules["layer" + str(i)](out)
-            out = F.relu(out)
-        out = self._modules["layer" + str(len(self._modules) - 1)](out)
+        for layer in self.layers[:-1]:
+            out = F.relu(layer(out))
+        out = self.layers[-1](out)
         return out
 
 
@@ -59,6 +59,11 @@ class Emulator:
         self.test_size = test_size
         self.preconditioner = preconditioner  # need to have forward and backward methods for transf and inverse transf
         self.model = None
+
+        # input, output dimensions, and parameter names
+        self.idim = None
+        self.odim = None
+        self.param_keys = None  # TODO: retrieve from function signature instead
 
     def _prepare_data(self, func, samples):
         """
@@ -105,6 +110,13 @@ class Emulator:
             X, Y, test_size=self.test_size
         )
 
+        # save input, output dimensions, and parameter names
+        self.idim = X_train.shape[1]
+        self.odim = Y_train.shape[1]
+        self.param_keys = list(
+            samples.keys()
+        )  # TODO: retrieve from function signature instead
+
         return X_train, X_test, Y_train, Y_test
 
     def _train(self, X_train, Y_train):
@@ -149,7 +161,7 @@ class Emulator:
         """
         raise NotImplementedError
 
-    def _build_func(self, param_keys):
+    def _build_func(self):
         """
         Build a function that can be used to emulate the original function
 
@@ -166,7 +178,7 @@ class Emulator:
         """
 
         def emulated_func(**kwargs):
-            values = [kwargs.get(k, None) for k in param_keys]
+            values = [kwargs.get(k, None) for k in self.param_keys]
             if None in values:
                 raise ValueError("Missing argument")
             res = self._predict(values)
@@ -178,7 +190,7 @@ class Emulator:
         emulated_func.emulator = self
         return emulated_func
 
-    def emulate(self, func, samples):
+    def emulate(self, func, samples, pretrained=None):
         """
         Emulate a function
 
@@ -196,11 +208,82 @@ class Emulator:
             Function that can be used to emulate the original function. The function has a
             reference to the emulator instance in the attribute `emulator`.
         """
+        if pretrained is not None:
+            self.load(pretrained)
+            return self._build_func()
         X_train, X_test, Y_train, Y_test = self._prepare_data(func, samples)
         self._train(X_train, Y_train)
         self._test(X_test, Y_test)
-        emulated_func = self._build_func(samples.keys())
+        emulated_func = self._build_func()
         return emulated_func
+
+    def _save(self, store):
+        """
+        Save the emulator to a datastore
+
+        Parameters
+        ----------
+        store : dict
+            DataStore to save the emulator to
+        """
+        raise NotImplementedError
+
+    def _load(self, store):
+        """
+        Load the emulator from a datastore
+
+        Parameters
+        ----------
+        store : dict
+            DataStore to load the emulator from
+        """
+        raise NotImplementedError
+
+    def save(self, filename):
+        """
+        Save the emulator to a file
+
+        Parameters
+        ----------
+        filename : str
+            Filename to save the emulator to
+        """
+        # always save the input and output dimensions
+        store = {
+            "in": self.idim,
+            "out": self.odim,
+            "param_keys": self.param_keys,
+        }
+        self._save(store)
+        if self.preconditioner is not None:
+            if not hasattr(self.preconditioner, "_save"):
+                raise ValueError("Cannot save a preconditioner without a _save method")
+            store["preconditioner"] = {}
+            self.preconditioner._save(store["preconditioner"])
+        torch.save(store, filename)  # shorter to write than pickle
+
+    def load(self, filename):
+        """
+        Load the emulator from a file
+
+        Parameters
+        ----------
+        filename : str
+            Filename to load the emulator from
+        """
+        store = torch.load(filename)
+
+        self.idim = store["in"]
+        self.odim = store["out"]
+        self.param_keys = store["param_keys"]
+
+        if "preconditioner" in store:
+            if self.preconditioner is None:
+                raise ValueError(
+                    "Cannot load a preconditioner into an emulator without one"
+                )
+            self.preconditioner._load(store["preconditioner"])
+        self._load(store)
 
 
 class TorchEmulator(Emulator):
@@ -353,6 +436,32 @@ class TorchEmulator(Emulator):
         res = self.model(x).detach().cpu().numpy()
         return res
 
+    def _save(self, store):
+        """
+        Save the emulator model to a file
+
+        Parameters
+        ----------
+        store: dict
+            The dictionary that will be stored to disk
+
+        """
+        store["model"] = self.model.state_dict()
+
+    def _load(self, store):
+        """
+        Load the emulator model from a file
+
+        Parameters
+        ----------
+        store: dict
+            The dictionary that will be stored to disk
+        """
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.model = self.NNClass(store["in"], store["out"])
+        self.model.load_state_dict(store["model"])
+        self.model.to(device)
+
 
 class SklearnEmulator(Emulator):
     def __init__(
@@ -435,6 +544,29 @@ class SklearnEmulator(Emulator):
         res = self.model.predict([x])[0]
         return res
 
+    def _save(self, store):
+        """
+        Save the emulator model to a file
+
+        Parameters
+        ----------
+        store: dict
+            The dictionary that will be stored to disk
+
+        """
+        store["model"] = self.model
+
+    def _load(self, store):
+        """
+        Load the emulator model from a file
+
+        Parameters
+        ----------
+        store: dict
+            The dictionary that will be stored to disk
+        """
+        self.model = store["model"]
+
 
 class GPyEmulator(Emulator):
     def __init__(
@@ -515,6 +647,30 @@ class GPyEmulator(Emulator):
         res = self.model.predict(np.array([x]))
         return res[0][0]
 
+    def _save(self, store):
+        """
+        Save the emulator model to a file
+
+        Parameters
+        ----------
+        store: dict
+            The dictionary that will be stored to disk
+        """
+        store["model"] = self.model.to_dict()
+
+    def _load(self, store):
+        """
+        Load the emulator model from a file
+
+        Parameters
+        ----------
+        store: dict
+            The dictionary that will be stored to disk
+        """
+        import GPy
+
+        self.model = GPy.models.GPRegression.from_dict(store["model"])
+
 
 # the main emulator interface
 class emulate:
@@ -523,6 +679,8 @@ class emulate:
         samples=None,
         emulator_class=None,
         backend="torch",
+        save=None,
+        load=None,
         **kwargs,
     ):
         """
@@ -536,6 +694,10 @@ class emulate:
             The class of the emulator to use. If None, the default emulator for the specified backend will be used.
         backend : str, optional
             The backend library to use for the emulator. Currently supported options are "torch" and "sklearn". Default is "torch".
+        save : str, optional
+            The path to the file to save the emulator to. If None, the emulator will not be saved. Default is None.
+        load : str, optional
+            The path to the file to load the emulator from. If None, the emulator will not be loaded. Default is None.
         **kwargs
             Additional keyword arguments to pass to the emulator constructor.
 
@@ -547,6 +709,10 @@ class emulate:
             The class of the emulator used for emulation.
         em : emulator_class
             An instance of the emulator used for emulation.
+        save : str
+            The path to the file to save the emulator to.
+        load : str
+            The path to the file to load the emulator from.
 
         Methods
         -------
@@ -555,6 +721,8 @@ class emulate:
         """
 
         self.samples = samples
+        self.save = save
+        self.load = load
 
         # select the backend
         if backend == "torch":
@@ -592,4 +760,7 @@ class emulate:
         callable
             The emulator function.
         """
-        return self.em.emulate(func, self.samples)
+        emulated = self.em.emulate(func, self.samples, pretrained=self.load)
+        if self.save is not None:
+            self.em.save(self.save)
+        return emulated


### PR DESCRIPTION
support saving models with syntax of
```python
@emulate(samples={
    'a': np.random.rand(100),
    'b': np.random.rand(100)
}, backend='sklearn', save="test.pkl")
def test_em(a=1, b=1):
    x = np.linspace(0, 10, 100)
    return np.sin(a*x) + np.sin(b*x)
```
and then loading it with
```python
@emulate(backend='sklearn', load="test.pkl")
def test_em(a=1, b=1):
    x = np.linspace(0, 10, 100)
    return np.sin(a*x) + np.sin(b*x)
```

