### PR TITLE
support loading a collection which contains everything

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -354,7 +354,7 @@ name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
 category = "main"
-optional = true
+optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
@@ -2551,14 +2551,14 @@ testing = ["flaky (>=3.4.0)", "freezegun (>=0.3.11)", "pathlib2 (>=2.3.3)", "psu
 
 [[package]]
 name = "tqdm"
-version = "4.64.1"
+version = "4.65.0"
 description = "Fast, Extensible Progress Meter"
 category = "main"
-optional = true
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+optional = false
+python-versions = ">=3.7"
 files = [
-    {file = "tqdm-4.64.1-py2.py3-none-any.whl", hash = "sha256:6fee160d6ffcd1b1c68c65f14c829c22832bc401726335ce92c52d395944a6a1"},
-    {file = "tqdm-4.64.1.tar.gz", hash = "sha256:5f4f682a004951c1b450bc753c710e9280c5746ce6ffedee253ddbcbf54cf1e4"},
+    {file = "tqdm-4.65.0-py3-none-any.whl", hash = "sha256:c4f53a17fe37e132815abceec022631be8ffe1b9381c2e6e30aa70edc99e9671"},
+    {file = "tqdm-4.65.0.tar.gz", hash = "sha256:1871fb68a86b8fb3b59ca4cdd3dcccbc7e6d613eeed31f4c332531977b89beb5"},
 ]
 
 [package.dependencies]
@@ -2751,4 +2751,4 @@ test = ["pytest", "black", "isort", "flake8", "flake8-docstrings", "pytest-cov"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4.0"
-content-hash = "412db7cccbd4a57d9576a8a8c333774f8ae50c6b2773c5fdeb6e95ca61600bb6"
+content-hash = "918e5cf97bab4535931d3f984c005035d85ba2e638c111b9c7d2438e7b21ea71"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ jaxlib = "^0.4.4"
 optax = "^0.1.4"
 flax = "^0.6.4"
 scikit-learn = "^1.2.1"
+tqdm = "^4.65.0"
 
 [tool.poetry.extras]
 test = [

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -1,0 +1,27 @@
+import os
+import pickle
+
+import numpy as np
+
+from galilei import emulate
+from galilei.experimental import collect
+from galilei.sampling import build_samples
+
+
+def test_collect():
+    @collect(samples=build_samples({"a": [0, 2], "b": [0, 2]}, 100), save="_test.pkl")
+    def test_em(a, b):
+        x = np.linspace(0, 10, 100)
+        return np.sin(a * x) + np.sin(b * x)
+
+    @emulate(collection="_test.pkl")
+    def test_em(a, b):
+        pass
+
+    # if collection loaded correctly, this should work
+    output = test_em(1, 1)
+    assert output.shape == (100,)
+
+    # clean up
+    if os.path.exists("_test.pkl"):
+        os.remove("_test.pkl")

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -14,7 +14,7 @@ def test_collect():
         x = np.linspace(0, 10, 100)
         return np.sin(a * x) + np.sin(b * x)
 
-    @emulate(collection="_test.pkl")
+    @emulate(collection="_test.pkl", backend="sklearn")
     def test_em(a, b):
         pass
 


### PR DESCRIPTION
Allow loading a collection of precomputed output. The input is a path to a `collection` that is a dictionary with keys `X`, `Y` and `samples`. 

```python
@emulate(collection="test.pkl")
def test(a, b):
    pass
```